### PR TITLE
New: Add `checkTitle` output options

### DIFF
--- a/.changeset/real-flowers-sleep.md
+++ b/.changeset/real-flowers-sleep.md
@@ -1,0 +1,8 @@
+---
+'danger-plugin-prfect': minor
+---
+
+Add `checkTitle` output options
+
+Allows for customising response level. Also returns an object of results
+to allow consumers to craft their own response message.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,10 @@ import { checkTitle } from 'danger-plugin-prfect'
 checkTitle()
 ```
 
+### checkTitle
+
+Checks for subject length, ~~capitalisation,~~ ~~trailing punctuation,~~ and
+imperative mood.
+
 [npm-url]: https://www.npmjs.com/package/danger-plugin-prfect
 [npm-img]: https://img.shields.io/npm/v/danger-plugin-prfect.svg?style=flat-square

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,16 +1,16 @@
-/* eslint-disable no-return-assign */
 import anyTest, { TestFn } from 'ava'
 
+import { checkTitle } from '../../dist/index.js'
 // eslint-disable-next-line import/extensions
-import { checkTitle } from '../index'
+import { IMPERATIVE_ERROR, LENGTH_ERROR, LENGTH_WARNING } from '../messages'
 
 const test = anyTest as TestFn<GlobalContext>
 
 interface GlobalContext {
-	warn: string
-	message: string
-	fail: string
-	markdown: string
+	warn: string[]
+	message: string[]
+	fail: string[]
+	markdown: string[]
 }
 
 declare const global: {
@@ -22,17 +22,14 @@ declare const global: {
 }
 
 test.beforeEach((t) => {
-	global.warn = (m: string) => (t.context.warn = m)
-	global.message = (m: string) => (t.context.message = m)
-	global.fail = (m: string) => (t.context.fail = m)
-	global.markdown = (m: string) => (t.context.markdown = m)
-})
-
-test.afterEach((t) => {
-	global.warn = () => (t.context.warn = '')
-	global.message = () => (t.context.message = '')
-	global.fail = () => (t.context.fail = '')
-	global.markdown = () => (t.context.markdown = '')
+	t.context.warn = []
+	t.context.message = []
+	t.context.fail = []
+	t.context.markdown = []
+	global.warn = (m: string) => t.context.warn.push(m)
+	global.message = (m: string) => t.context.message.push(m)
+	global.fail = (m: string) => t.context.fail.push(m)
+	global.markdown = (m: string) => t.context.markdown.push(m)
 })
 
 function checkPr({ title }: { title: string }) {
@@ -45,10 +42,39 @@ function checkPr({ title }: { title: string }) {
 
 test.serial('show failure when not using imperative mood', async (t) => {
 	checkPr({ title: 'Fixes a bug in production' })
-	t.is(t.context.fail, 'PR titles should use the imperative mood.')
+	t.true(t.context.fail.includes(IMPERATIVE_ERROR))
 })
 
 test.serial('shows no message when using imperative mood', async (t) => {
 	checkPr({ title: 'Fix a bug in production' })
-	t.is(t.context.fail, undefined)
+	t.false(t.context.fail.includes(IMPERATIVE_ERROR))
+})
+
+test.serial('can set a custom response level', async (t) => {
+	checkTitle('fixes a bug in production.', { imperativeMood: 'warn' })
+	t.false(t.context.fail.includes(IMPERATIVE_ERROR))
+	t.true(t.context.warn.includes(IMPERATIVE_ERROR))
+})
+
+test.serial('warns when a title is between 50 and 72 characters', async (t) => {
+	checkTitle('warns when a title is between 50 and 72 characters.')
+	t.true(t.context.warn.includes(LENGTH_WARNING))
+})
+
+test.serial(
+	'shows a failure when a title is greater than 72 characters',
+	async (t) => {
+		checkTitle(
+			'Advanced bullshit cutting-edge cable Chiba sanpaku amalgam unfolding psychoactive program.'
+		)
+		t.true(t.context.fail.includes(LENGTH_ERROR))
+	}
+)
+
+test.serial('logs no message when set to returnOnly', async (t) => {
+	checkTitle('fixes a bug in production.', { returnOnly: true })
+	t.is(t.context.fail.length, 0)
+	t.is(t.context.warn.length, 0)
+	t.is(t.context.message.length, 0)
+	t.is(t.context.markdown.length, 0)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
+import nlp from 'compromise'
 // Provides dev-time type structures for  `danger` - doesn't affect runtime.
 import { DangerDSLType } from 'danger/distribution/dsl/DangerDSL.js'
-import nlp from 'compromise'
+
+import {
+	IMPERATIVE_ERROR,
+	IMPERATIVE_TIP,
+	LENGTH_ERROR,
+	LENGTH_TIP,
+	LENGTH_WARNING,
+} from './messages.js'
 
 declare const danger: DangerDSLType
 // Declare function message(message: string): void
@@ -8,44 +16,91 @@ declare function warn(message: string): void
 declare function fail(message: string): void
 declare function markdown(message: string): void
 
+interface CheckTitleOptions {
+	/**
+	 * Error type for imperative mood check.
+	 * @default 'fail'
+	 */
+	imperativeMood?: false | 'warn' | 'fail'
+	/**
+	 * Should a character limit be enforced.
+	 * @default true
+	 */
+	titleLength?: boolean
+	returnOnly?: boolean
+}
+
+type CheckResult = 'pass' | 'warn' | 'fail'
+
+interface CheckOutput {
+	result?: CheckResult
+	message?: string
+	tip?: string
+}
+
 /**
  * Validate PR titles
  *
  * Checks for subject length, capitalisation, trailing punctuation,
  * and imperative mood.
  */
-export function checkTitle() {
-	let { title } = danger.github.pr
-	/** @todo Ignore "tag" prefixes. */
-	let isImperative = Boolean(nlp(title).verbs().isImperative().text())
-
-	if (!isImperative) {
-		fail('PR titles should use the imperative mood.')
-		markdown(`
-*Imperative mood* just means “spoken or written as if giving a command
-or instruction”.
-
-💡 **Tip:** A properly formed Git commit subject line should always be
-able to complete the following sentence:
-
-> If applied, this commit will…
-		`)
+export function checkTitle(title?: string, options?: CheckTitleOptions) {
+	title ||= danger.github.pr.title
+	let { imperativeMood, titleLength, returnOnly } = options || {
+		imperativeMood: 'fail',
+		titleLength: true,
+		returnOnly: false,
 	}
 
-	if (50 <= title.length && title.length <= 72) {
-		warn('Great PR titles are 50 characters or fewer.')
+	let imperativeMoodOutput: CheckOutput
+	if (imperativeMood) {
+		/** @todo Ignore "tag" prefixes. */
+		let isImperative = Boolean(nlp(title).verbs().isImperative().text())
+
+		if (!isImperative && !returnOnly) {
+			if (imperativeMood === 'fail') fail(IMPERATIVE_ERROR)
+			if (imperativeMood === 'warn') warn(IMPERATIVE_ERROR)
+			markdown(IMPERATIVE_TIP)
+		}
+
+		imperativeMoodOutput = {
+			result: isImperative ? 'pass' : imperativeMood,
+			message: !isImperative && IMPERATIVE_ERROR,
+			tip: !isImperative && IMPERATIVE_TIP,
+		}
 	}
 
-	if (72 < title.length) {
-		fail(
-			'PR titles must be less than 72 characters to avoid being truncated.'
-		)
+	let titleLengthOutput: CheckOutput
+	if (titleLength) {
+		let lengthResult: CheckResult = 'pass'
+		let lengthMessage: string
+		if (50 <= title.length && title.length <= 72) {
+			if (!returnOnly) warn(LENGTH_WARNING)
+			lengthResult = 'warn'
+			lengthMessage = LENGTH_WARNING
+		}
+
+		if (72 < title.length) {
+			if (!returnOnly) fail(LENGTH_ERROR)
+			lengthResult = 'fail'
+			lengthMessage = LENGTH_ERROR
+		}
+
+		let showLengthTip = false
+		if (50 <= title.length) {
+			if (!returnOnly) markdown(LENGTH_TIP)
+			showLengthTip = true
+		}
+
+		titleLengthOutput = {
+			result: lengthResult,
+			message: lengthMessage,
+			tip: showLengthTip && LENGTH_TIP,
+		}
 	}
 
-	if (50 <= title.length) {
-		markdown(`
-💡 **Tip:** If you’re having a hard time summarizing, you might be
-committing too many changes at once.
-		`)
+	return {
+		imperativeMood: imperativeMoodOutput,
+		titleLength: titleLengthOutput,
 	}
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const IMPERATIVE_ERROR = 'PR titles should use the imperative mood.'
+export const IMPERATIVE_TIP = `
+*Imperative mood* just means “spoken or written as if giving a command or instruction”.
+
+💡 **Tip:** A properly formed Git commit subject line should always be able to complete the following sentence:
+
+> If applied, this commit will…
+`
+export const LENGTH_WARNING = 'Great PR titles are 50 characters or fewer.'
+export const LENGTH_ERROR =
+	'PR titles must be less than 72 characters to avoid being truncated.'
+export const LENGTH_TIP = `
+💡 **Tip:** If you’re having a hard time summarizing, you might be
+committing too many changes at once.
+`


### PR DESCRIPTION
Allows for customising response level. Also returns an object of results
to allow consumers to craft their own response message.
